### PR TITLE
Add Inline support to separate fields

### DIFF
--- a/embed.go
+++ b/embed.go
@@ -230,6 +230,13 @@ func (e *Embed) Truncate() *Embed {
 	return e
 }
 
+// Adds last field as InLine
+func (e *Embed) MakeFieldInline() *Embed {
+	length := len(e.Fields)-1
+	e.Fields[length].Inline = true
+	return e
+}
+
 // TruncateFields truncates fields that are too long
 func (e *Embed) TruncateFields() *Embed {
 	if len(e.Fields) > 25 {


### PR DESCRIPTION
With this function, it's possible to define certain fields to be inline. Still without having to pass an inline value in the `AddField` function.

As I was working with this library, I felt the need to use this functionality. Hence, created a PR to add it for other users.